### PR TITLE
Support nested block children

### DIFF
--- a/pages/[id].js
+++ b/pages/[id].js
@@ -82,7 +82,9 @@ const renderBlock = (block) => {
           <summary>
             <Text text={value.text} />
           </summary>
-          It's a toggle!
+          {value.children?.map((block) => (
+            <Fragment key={block.id}>{renderBlock(block)}</Fragment>
+          ))}
         </details>
       );
     case "child_page":
@@ -135,10 +137,32 @@ export const getStaticProps = async (context) => {
   const page = await getPage(id);
   const blocks = await getBlocks(id);
 
+  // Retrieve block children for nested blocks (one level deep), for example toggle blocks
+  // https://developers.notion.com/docs/working-with-page-content#reading-nested-blocks
+  const childBlocks = await Promise.all(
+    blocks
+      .filter((block) => block.has_children)
+      .map(async (block) => {
+        return {
+          id: block.id,
+          children: await getBlocks(block.id),
+        };
+      })
+  );
+  const blocksWithChildren = blocks.map((block) => {
+    // Add child blocks if the block should contain children but none exists
+    if (block.has_children && !block[block.type].children) {
+      block[block.type]["children"] = childBlocks.find(
+        (x) => x.id === block.id
+      )?.children;
+    }
+    return block;
+  });
+
   return {
     props: {
       page,
-      blocks,
+      blocks: blocksWithChildren,
     },
     revalidate: 1,
   };


### PR DESCRIPTION
Retrieve block children (one level deep) to make toggles work. 
https://developers.notion.com/docs/working-with-page-content#reading-nested-blocks

Closes #7 
