### PR TITLE
Add divider and quote block support

### DIFF
--- a/pages/[id].js
+++ b/pages/[id].js
@@ -99,6 +99,10 @@ const renderBlock = (block) => {
           {caption && <figcaption>{caption}</figcaption>}
         </figure>
       );
+    case "divider":
+      return <hr key={id} />;
+    case "quote":
+      return <blockquote key={id}>{value.text[0].plain_text}</blockquote>;
     default:
       return `❌ Unsupported block (${
         type === "unsupported" ? "unsupported by Notion API" : type


### PR DESCRIPTION
Hello! I've been using this great system. Thank you very much.

The Notion API has been updated to support divider blocks and quote blocks, so I've implemented them.

- https://developers.notion.com/changelog/table-of-contents-and-divider-block-types-are-now-supported
- https://developers.notion.com/changelog/callouts-and-quote-blocks-are-now-supported