### PR TITLE
Fixed caption not existing in notion api for image blocks

### DIFF
--- a/pages/[id].js
+++ b/pages/[id].js
@@ -92,11 +92,12 @@ const renderBlock = (block) => {
     case "image":
       const src =
         value.type === "external" ? value.external.url : value.file.url;
-      const caption = value.caption ? value.caption[0].plain_text : "";
+      // const caption = value.caption ? value.caption[0].plain_text : "";
       return (
         <figure>
-          <img src={src} alt={caption} />
-          {caption && <figcaption>{caption}</figcaption>}
+          <img src={src}/>
+          {/* <img src={src} alt={caption} /> */}
+          {/* {caption && <figcaption>{caption}</figcaption>} */}
         </figure>
       );
     case "divider":


### PR DESCRIPTION
Commented out the use of caption for Image Block until Notion API adds support for it. Fixes #20 